### PR TITLE
Optimize and simplify PyInstaller build packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             artifact_path: dist/Fleasion-v*.exe
           - name: Linux
             os: ubuntu-latest
-            artifact_path: dist/Fleasion-v*
+            artifact_path: dist/Fleasion-v*-Linux
           - name: macOS
             os: macos-latest
             artifact_path: dist/Fleasion-v*-MacOS-Universal.zip
@@ -62,9 +62,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libportaudio2 libpipewire-0.3-0 libspa-0.2-modules libpulse0
 
-      - name: Build Linux proxy helper
-        if: runner.os == 'Linux'
-        run: uv run pyinstaller --clean --noconfirm FleasionLinuxProxyHelper.spec
+      - name: Install UPX
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install upx -y --no-progress
+          upx --version
 
       - name: Build Windows package
         if: runner.os == 'Windows'
@@ -77,7 +80,7 @@ jobs:
       - name: Verify Linux audio runtime
         if: runner.os == 'Linux'
         run: |
-          archive_listing="$(uv run pyi-archive_viewer -b -l dist/Fleasion-v*)"
+          archive_listing="$(uv run pyi-archive_viewer -b -l dist/Fleasion-v*-Linux)"
           printf '%s\n' "$archive_listing" | grep -Ei 'portaudio|pulse|pipewire|jack|alsa|sound' || true
           if [[ "$archive_listing" =~ lib(portaudio|asound|jack|pulse|pulsecommon-|pipewire-) ]]; then
             echo "Linux package must use host audio backend libraries, not the GitHub runner copies." >&2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload package
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: Fleasion-v${{ env.APP_VERSION }}-Linux
           path: ${{ matrix.artifact_path }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -82,9 +82,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zip libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libportaudio2 libpipewire-0.3-0 libspa-0.2-modules libpulse0
 
-      - name: Build Linux proxy helper
-        if: runner.os == 'Linux'
-        run: uv run pyinstaller --clean --noconfirm FleasionLinuxProxyHelper.spec
+      - name: Install UPX
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install upx -y --no-progress
+          upx --version
 
       - name: Build Windows package
         if: runner.os == 'Windows'
@@ -97,7 +100,7 @@ jobs:
       - name: Verify Linux audio runtime
         if: runner.os == 'Linux'
         run: |
-          archive_listing="$(uv run pyi-archive_viewer -b -l dist/Fleasion-v*)"
+          archive_listing="$(uv run pyi-archive_viewer -b -l dist/Fleasion-v*-Linux)"
           printf '%s\n' "$archive_listing" | grep -Ei 'portaudio|pulse|pipewire|jack|alsa|sound' || true
           if [[ "$archive_listing" =~ lib(portaudio|asound|jack|pulse|pulsecommon-|pipewire-) ]]; then
             echo "Linux package must use host audio backend libraries, not the GitHub runner copies." >&2
@@ -108,7 +111,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           cd dist
-          zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip" "Fleasion-v${{ needs.prepare.outputs.app_version }}"
+          zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip" "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux"
 
       - name: Install Rosetta
         if: runner.os == 'macOS'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,7 +22,7 @@ jobs:
       release_tag: v${{ steps.version.outputs.app_version }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
 
@@ -52,8 +52,8 @@ jobs:
             artifact_path: dist/Fleasion-v*.exe
           - name: Linux
             os: ubuntu-latest
-            artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip
-            artifact_path: dist/Fleasion-v*-Linux.zip
+            artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux
+            artifact_path: dist/Fleasion-v*-Linux
           - name: macOS
             os: macos-latest
             artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip
@@ -61,12 +61,12 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.main_sha }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -80,7 +80,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y zip libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libportaudio2 libpipewire-0.3-0 libspa-0.2-modules libpulse0
+          sudo apt-get install -y libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libportaudio2 libpipewire-0.3-0 libspa-0.2-modules libpulse0
 
       - name: Install UPX
         if: runner.os == 'Windows'
@@ -107,12 +107,6 @@ jobs:
             exit 1
           fi
 
-      - name: Package Linux release zip
-        if: runner.os == 'Linux'
-        run: |
-          cd dist
-          zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip" "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux"
-
       - name: Install Rosetta
         if: runner.os == 'macOS'
         run: sudo softwareupdate --install-rosetta --agree-to-license
@@ -137,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main for release
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.main_sha }}
 
@@ -151,7 +145,7 @@ jobs:
       - name: Download Linux release asset
         uses: actions/download-artifact@v8
         with:
-          name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip
+          name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux
           path: release-files
           skip-decompress: true
 
@@ -166,7 +160,7 @@ jobs:
         run: |
           find release-files -maxdepth 1 -type f -print | sort
           test -f "release-files/Fleasion-v${{ needs.prepare.outputs.app_version }}.exe"
-          test -f "release-files/Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip"
+          test -f "release-files/Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux"
           test -f "release-files/Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip"
           test "$(find release-files -maxdepth 1 -type f -name 'Fleasion-v*' | wc -l)" -eq 3
 

--- a/Fleasion.spec
+++ b/Fleasion.spec
@@ -1,20 +1,245 @@
 # -*- mode: python ; coding: utf-8 -*-
+from collections.abc import Callable, Iterable
 import importlib.util
-import os, re, pathlib, sys
-from PyInstaller.utils.hooks import collect_all, collect_submodules
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import TYPE_CHECKING, TypeVar
 
+from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules
 
-_paths_src = pathlib.Path('src/Fleasion/utils/paths.py').read_text()
-_version = re.search(r"APP_VERSION\s*=\s*['\"]([^'\"]+)['\"]", _paths_src).group(1)
-_macos_target_arch = os.environ.get('MACOS_TARGET_ARCH', 'universal2') if sys.platform == 'darwin' else None
-_bundled_macos_helpers = {
-    'arm64': pathlib.Path('dist/fleasion-proxy-helper-arm64'),
-    'x86_64': pathlib.Path('dist/fleasion-proxy-helper-x86_64'),
+if TYPE_CHECKING:
+    from PyInstaller.building.api import COLLECT, EXE, PYZ
+    from PyInstaller.building.build_main import Analysis
+    from PyInstaller.building.osx import BUNDLE
+
+type CollectionEntry = tuple[str, str]
+type TocEntry = tuple[object, ...]
+TocItem = TypeVar('TocItem', bound=tuple[object, ...])
+
+_QT_HIDDEN_IMPORTS = [
+    'PyQt6.QtCore',
+    'PyQt6.QtGui',
+    'PyQt6.QtNetwork',
+    'PyQt6.QtOpenGL',
+    'PyQt6.QtOpenGLWidgets',
+    'PyQt6.QtWidgets',
+]
+
+_OPENGL_HIDDEN_IMPORTS = [
+    'OpenGL.platform.glx',
+    'OpenGL.platform.egl',
+]
+
+_COMPILED_HIDDEN_IMPORTS = [
+    'certifi',
+    'orjson',
+    'zstandard',
+]
+
+_WINDOWS_HIDDEN_IMPORTS = [
+    'win32crypt',
+    'win32api',
+    'win32con',
+    'pywintypes',
+    'winreg',
+]
+
+_BASE_EXCLUDES = [
+    'PySide6',
+    'PyQt5',
+    'mitmproxy',  # removed - replaced by proxy/server.py
+    'mitmproxy_rs',  # removed
+    'wsproto',  # mitmproxy dep, no longer needed
+    'h2',  # mitmproxy dep, no longer needed
+    'hyperframe',  # mitmproxy dep, no longer needed
+]
+
+_NUMPY_EXCLUDES = [
+    'numpy._pyinstaller.tests',
+    'numpy.conftest',
+    'numpy.f2py',
+]
+
+_QT_EXCLUDES = [
+    'PyQt6.QAxContainer',
+    'PyQt6.Qsci',
+    'PyQt6.Qt3DAnimation',
+    'PyQt6.Qt3DCore',
+    'PyQt6.Qt3DExtras',
+    'PyQt6.Qt3DInput',
+    'PyQt6.Qt3DLogic',
+    'PyQt6.Qt3DRender',
+    'PyQt6.QtBluetooth',
+    'PyQt6.QtCharts',
+    'PyQt6.QtDataVisualization',
+    'PyQt6.QtDesigner',
+    'PyQt6.QtGraphs',
+    'PyQt6.QtGraphsWidgets',
+    'PyQt6.QtHelp',
+    'PyQt6.QtMultimedia',
+    'PyQt6.QtMultimediaWidgets',
+    'PyQt6.QtNetworkAuth',
+    'PyQt6.QtNfc',
+    'PyQt6.QtPdf',
+    'PyQt6.QtPdfWidgets',
+    'PyQt6.QtPositioning',
+    'PyQt6.QtPrintSupport',
+    'PyQt6.QtQml',
+    'PyQt6.QtQuick',
+    'PyQt6.QtQuick3D',
+    'PyQt6.QtQuickWidgets',
+    'PyQt6.QtRemoteObjects',
+    'PyQt6.QtSensors',
+    'PyQt6.QtSerialPort',
+    'PyQt6.QtSpatialAudio',
+    'PyQt6.QtSql',
+    'PyQt6.QtStateMachine',
+    'PyQt6.QtSvg',
+    'PyQt6.QtSvgWidgets',
+    'PyQt6.QtTest',
+    'PyQt6.QtTextToSpeech',
+    'PyQt6.QtWebChannel',
+    'PyQt6.QtWebEngineCore',
+    'PyQt6.QtWebEngineQuick',
+    'PyQt6.QtWebEngineWidgets',
+    'PyQt6.QtWebSockets',
+    'PyQt6.QtXml',
+    'PyQt6.uic',
+]
+
+_UNUSED_QT_RUNTIME_NAMES = {
+    'libqpdf.so',
+    'libqtiff.so',
+    'libQt6Pdf.so.6',
+    'qpdf.dll',
+    'qtiff.dll',
+    'Qt6Pdf.dll',
+    'libqpdf.dylib',
+    'libqtiff.dylib',
+    'QtPdf.framework',
 }
-_bundled_legacy_macos_helper = pathlib.Path('dist/fleasion-proxy-helper')
-_bundled_linux_helper = pathlib.Path('dist/fleasion-linux-proxy-helper')
 
-datas = [
+_UNUSED_QT_RUNTIME_PATH_PARTS = (
+    '/PyQt6/Qt6/translations/',
+    '\\PyQt6\\Qt6\\translations\\',
+    'PyQt6/Qt6/translations/',
+    'PyQt6\\Qt6\\translations\\',
+)
+
+_HOST_AUDIO_LIB_PREFIXES = (
+    'libportaudio.so',
+    'libasound.so',
+    'libjack.so',
+    'libpulse.so',
+    'libpulsecommon-',
+    'libpipewire-',
+)
+
+
+def _run_pyinstaller_spec(spec_path: str, *, env: dict[str, str] | None = None) -> None:
+    build_env = os.environ.copy()
+    if env:
+        build_env.update(env)
+    subprocess.run(
+        [
+            sys.executable,
+            '-m',
+            'PyInstaller',
+            '--clean',
+            '--noconfirm',
+            spec_path,
+        ],
+        check=True,
+        env=build_env,
+    )
+
+
+def _read_app_version() -> str:
+    paths_src = Path('src/Fleasion/utils/paths.py').read_text()
+    match = re.search(r"APP_VERSION\s*=\s*['\"]([^'\"]+)['\"]", paths_src)
+    if match is None:
+        raise SystemExit('Could not find APP_VERSION in src/Fleasion/utils/paths.py.')
+    return match.group(1)
+
+
+def _collect_package(package: str) -> None:
+    package_datas, package_binaries, package_hiddenimports = collect_all(package)
+    datas.extend(package_datas)
+    binaries.extend(package_binaries)
+    hiddenimports.extend(package_hiddenimports)
+
+
+def _collect_optional_package(package: str) -> None:
+    if importlib.util.find_spec(package):
+        _collect_package(package)
+
+
+def _entry_name_matches(entry: TocEntry, names: set[str]) -> bool:
+    return any(Path(str(part)).name in names for part in entry[:2])
+
+
+def _entry_path_contains(entry: TocEntry, path_parts: tuple[str, ...]) -> bool:
+    for part in entry[:2]:
+        text = str(part)
+        normalised = text.replace('\\', '/')
+        if any(path_part in text for path_part in path_parts):
+            return True
+        if 'PyQt6/Qt6/translations/' in normalised:
+            return True
+    return False
+
+
+def _is_unused_qt_runtime_entry(entry: TocEntry) -> bool:
+    return _entry_name_matches(
+        entry,
+        _UNUSED_QT_RUNTIME_NAMES,
+    ) or _entry_path_contains(entry, _UNUSED_QT_RUNTIME_PATH_PARTS)
+
+
+def _entry_name_startswith(entry: TocEntry, prefixes: tuple[str, ...]) -> bool:
+    return any(Path(str(part)).name.startswith(prefixes) for part in entry[:2])
+
+
+def _drop_entries(
+    entries: Iterable[TocItem],
+    predicate: Callable[[TocItem], bool],
+) -> list[TocItem]:
+    return [entry for entry in entries if not predicate(entry)]
+
+
+def _build_linux_helper() -> None:
+    _run_pyinstaller_spec('FleasionLinuxProxyHelper.spec')
+
+
+def _build_macos_helper(target_arch: str | None) -> None:
+    helper_env = {'MACOS_TARGET_ARCH': target_arch} if target_arch else None
+    _run_pyinstaller_spec('FleasionProxyHelper.spec', env=helper_env)
+    if target_arch in _bundled_macos_helpers:
+        shutil.copy2(_bundled_legacy_macos_helper, _bundled_macos_helpers[target_arch])
+
+
+_version = _read_app_version()
+_exe_name = f'Fleasion-v{_version}'
+if sys.platform.startswith('linux'):
+    _exe_name = f'{_exe_name}-Linux'
+_macos_target_arch = (
+    os.environ.get('MACOS_TARGET_ARCH', 'universal2')
+    if sys.platform == 'darwin'
+    else None
+)
+_use_upx = sys.platform == 'win32'
+_bundled_macos_helpers = {
+    'arm64': Path('dist/fleasion-proxy-helper-arm64'),
+    'x86_64': Path('dist/fleasion-proxy-helper-x86_64'),
+}
+_bundled_legacy_macos_helper = Path('dist/fleasion-proxy-helper')
+_bundled_linux_helper = Path('dist/fleasion-linux-proxy-helper')
+
+datas: list[CollectionEntry] = [
     ('src/Fleasion/fleasionlogoHR.ico', '.'),
     ('src/Fleasion/fleasionlogoHR.icns', '.'),
     ('src/Fleasion/macos_proxy_helper_daemon.py', '.'),
@@ -24,91 +249,60 @@ datas = [
     ('src/Fleasion/modifications/bundled/empty.mesh', 'Fleasion/modifications/bundled'),
     ('src/Fleasion/modifications/bundled/empty.tex', 'Fleasion/modifications/bundled'),
 ]
-binaries = []
+binaries: list[CollectionEntry] = []
 if sys.platform == 'win32':
     binaries.append(('src/Fleasion/cache/tools/ktx_to_png/ktx.dll', '.'))
-hiddenimports = []
+hiddenimports: list[str] = []
 
-# cryptography has Rust/C binary extensions that must be collected explicitly
-tmp_ret = collect_all('cryptography')
-datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-
-# numpy has C-extensions (.pyd files) that must be bundled - without this, the .exe fails with C-extension import errors
-tmp_ret = collect_all('numpy')
-datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-
-# PyQt6 has many optional sub-packages; collect_all ensures nothing is missed
-tmp_ret = collect_all('PyQt6')
-datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+# Keep Qt collection narrow. collect_all('PyQt6') pulls in QML/QtQuick,
+# Designer, SQL drivers, multimedia, translations, and other modules that the
+# app does not use, which more than doubles the one-file executable size.
+hiddenimports.extend(_QT_HIDDEN_IMPORTS)
 
 # PyOpenGL resolves platform backends dynamically. The upstream PyInstaller
 # hook includes GLX on Linux, but Wayland sessions can select EGL instead.
-hiddenimports += collect_submodules('OpenGL.arrays')
-hiddenimports += [
-    'OpenGL.platform.glx',
-    'OpenGL.platform.egl',
-]
-
-# zstandard is a compiled C extension - collect_all ensures the .pyd is bundled
-tmp_ret = collect_all('zstandard')
-datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+hiddenimports.extend(collect_submodules('OpenGL.arrays'))
+hiddenimports.extend(_OPENGL_HIDDEN_IMPORTS)
 
 # sounddevice/soundfile are single-file modules, but their native runtime
 # libraries live in sibling data packages that PyInstaller does not discover.
 for audio_runtime_package in ('_sounddevice_data', '_soundfile_data'):
-    if importlib.util.find_spec(audio_runtime_package):
-        tmp_ret = collect_all(audio_runtime_package)
-        datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-
-# orjson is a compiled extension - make sure it's included
-hiddenimports += collect_submodules('orjson')
-
-# zstandard may be needed for CDN payload decompression
-hiddenimports += collect_submodules('zstandard')
-
-# requests + urllib3 for CacheScraper API calls
-hiddenimports += collect_submodules('requests')
-hiddenimports += collect_submodules('urllib3')
+    _collect_optional_package(audio_runtime_package)
 
 # certifi provides a bundled public CA store for urllib HTTPS fallbacks
-tmp_ret = collect_all('certifi')
-datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+datas.extend(collect_data_files('certifi', includes=['cacert.pem']))
+hiddenimports.extend(_COMPILED_HIDDEN_IMPORTS)
 
 if sys.platform == 'win32':
     # win32 extensions (pywin32) - needed for .ROBLOSECURITY cookie decryption
-    hiddenimports += [
-        'win32crypt',
-        'win32api',
-        'win32con',
-        'pywintypes',
-        'winreg',
-    ]
+    hiddenimports.extend(_WINDOWS_HIDDEN_IMPORTS)
 elif sys.platform == 'darwin':
+    _build_macos_helper(_macos_target_arch)
     _wanted_macos_helpers = (
         [_bundled_macos_helpers[_macos_target_arch]]
         if _macos_target_arch in _bundled_macos_helpers
         else list(_bundled_macos_helpers.values())
     )
-    _existing_macos_helpers = [helper for helper in _wanted_macos_helpers if helper.exists()]
+    _existing_macos_helpers = [
+        helper for helper in _wanted_macos_helpers if helper.exists()
+    ]
     if not _existing_macos_helpers and _bundled_legacy_macos_helper.exists():
         _existing_macos_helpers = [_bundled_legacy_macos_helper]
     if not _existing_macos_helpers:
         raise SystemExit(
             'Missing dist/fleasion-proxy-helper-arm64 or dist/fleasion-proxy-helper-x86_64. '
-            'Build the macOS helper first with '
-            'PyInstaller or use ./scripts/build_macos.sh.'
+            'Fleasion.spec could not build the macOS helper.'
         )
     for helper in _existing_macos_helpers:
         datas.append((str(helper), '.'))
-    tmp_ret = collect_all('browser_cookie3')
-    datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-    tmp_ret = collect_all('Cryptodome')
-    datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+    _collect_package('browser_cookie3')
+    _collect_package('Cryptodome')
 elif sys.platform.startswith('linux'):
+    _build_linux_helper()
     if not _bundled_linux_helper.exists():
         raise SystemExit(
             'Missing dist/fleasion-linux-proxy-helper. '
-            'Build the Linux proxy helper first with FleasionLinuxProxyHelper.spec.'
+            'Fleasion.spec could not build the Linux proxy helper.'
         )
     datas.append((str(_bundled_linux_helper), '.'))
     datas.append(('src/Fleasion/linux_proxy_helper_daemon.py', '.'))
@@ -121,38 +315,24 @@ a = Analysis(
     hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=['pyinstaller_hooks/rthook_harden_dll_search.py'] if sys.platform == 'win32' else [],
-    excludes=[
-        'PySide6',
-        'PyQt5',
-        'mitmproxy',        # removed - replaced by proxy/server.py
-        'mitmproxy_rs',     # removed
-        'wsproto',          # mitmproxy dep, no longer needed
-        'h2',               # mitmproxy dep, no longer needed
-        'hyperframe',       # mitmproxy dep, no longer needed
-    ],
+    runtime_hooks=['pyinstaller_hooks/rthook_harden_dll_search.py']
+    if sys.platform == 'win32'
+    else [],
+    excludes=[*_BASE_EXCLUDES, *_NUMPY_EXCLUDES, *_QT_EXCLUDES],
     noarchive=False,
     optimize=0,
 )
+
+a.binaries = _drop_entries(a.binaries, _is_unused_qt_runtime_entry)
+a.datas = _drop_entries(a.datas, _is_unused_qt_runtime_entry)
 if sys.platform.startswith('linux'):
     # The sounddevice hook and dependency scan can collect the build machine's
     # audio backend stack. That can silence playback on other distros, so the
     # GUI player uses host PortAudio and host audio backend libraries.
-    _host_audio_lib_prefixes = (
-        'libportaudio.so',
-        'libasound.so',
-        'libjack.so',
-        'libpulse.so',
-        'libpulsecommon-',
-        'libpipewire-',
+    a.binaries = _drop_entries(
+        a.binaries,
+        lambda entry: _entry_name_startswith(entry, _HOST_AUDIO_LIB_PREFIXES),
     )
-    a.binaries = [
-        entry for entry in a.binaries
-        if not any(
-            pathlib.Path(str(part)).name.startswith(_host_audio_lib_prefixes)
-            for part in entry[:2]
-        )
-    ]
 pyz = PYZ(a.pure)
 
 exe = EXE(
@@ -161,18 +341,23 @@ exe = EXE(
     [] if sys.platform == 'darwin' else a.binaries,
     [] if sys.platform == 'darwin' else a.datas,
     [],
-    name=f'Fleasion-v{_version}',
+    name=_exe_name,
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=_use_upx,
     upx_exclude=[
-    'Qt6Core.dll', 'Qt6Gui.dll', 'Qt6Widgets.dll',
-    'Qt6Network.dll', 'Qt6OpenGL.dll', 'Qt6Svg.dll',
-    'libEGL.dll', 'libGLESv2.dll',
+        'Qt6Core.dll',
+        'Qt6Gui.dll',
+        'Qt6Widgets.dll',
+        'Qt6Network.dll',
+        'Qt6OpenGL.dll',
+        'Qt6Svg.dll',
+        'libEGL.dll',
+        'libGLESv2.dll',
     ],
     runtime_tmpdir=None,
-    console=False,          # no console window for end users
+    console=False,  # no console window for end users
     exclude_binaries=sys.platform == 'darwin',
     # uac_admin is intentionally NOT set here.
     # We handle elevation at runtime in app.py so the user can choose
@@ -197,7 +382,7 @@ if sys.platform == 'darwin':
         a.binaries,
         a.datas,
         strip=False,
-        upx=True,
+        upx=_use_upx,
         name='Fleasion',
     )
     app = BUNDLE(

--- a/Fleasion.spec
+++ b/Fleasion.spec
@@ -1,24 +1,29 @@
 # -*- mode: python ; coding: utf-8 -*-
-from collections.abc import Callable, Iterable
+from __future__ import annotations
+
 import importlib.util
 import os
-from pathlib import Path
 import re
 import shutil
 import subprocess
 import sys
-from typing import TYPE_CHECKING, TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from PyInstaller.utils.hooks import collect_all, collect_data_files, collect_submodules
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from typing import TypeAlias, TypeVar
+
     from PyInstaller.building.api import COLLECT, EXE, PYZ
     from PyInstaller.building.build_main import Analysis
     from PyInstaller.building.osx import BUNDLE
 
-type CollectionEntry = tuple[str, str]
-type TocEntry = tuple[object, ...]
-TocItem = TypeVar('TocItem', bound=tuple[object, ...])
+    CollectionEntry: TypeAlias = tuple[str, str]
+    TocEntry: TypeAlias = tuple[object, ...]
+    TocItem = TypeVar('TocItem', bound=tuple[object, ...])
+
 
 _QT_HIDDEN_IMPORTS = [
     'PyQt6.QtCore',
@@ -256,16 +261,16 @@ hiddenimports: list[str] = []
 
 # Keep Qt collection narrow. collect_all('PyQt6') pulls in QML/QtQuick,
 # Designer, SQL drivers, multimedia, translations, and other modules that the
-# app does not use, which more than doubles the one-file executable size.
+# app does not use, which more than doubles the one-file executable size
 hiddenimports.extend(_QT_HIDDEN_IMPORTS)
 
 # PyOpenGL resolves platform backends dynamically. The upstream PyInstaller
-# hook includes GLX on Linux, but Wayland sessions can select EGL instead.
+# hook includes GLX on Linux, but Wayland sessions can select EGL instead
 hiddenimports.extend(collect_submodules('OpenGL.arrays'))
 hiddenimports.extend(_OPENGL_HIDDEN_IMPORTS)
 
 # sounddevice/soundfile are single-file modules, but their native runtime
-# libraries live in sibling data packages that PyInstaller does not discover.
+# libraries live in sibling data packages that PyInstaller does not discover
 for audio_runtime_package in ('_sounddevice_data', '_soundfile_data'):
     _collect_optional_package(audio_runtime_package)
 
@@ -328,7 +333,7 @@ a.datas = _drop_entries(a.datas, _is_unused_qt_runtime_entry)
 if sys.platform.startswith('linux'):
     # The sounddevice hook and dependency scan can collect the build machine's
     # audio backend stack. That can silence playback on other distros, so the
-    # GUI player uses host PortAudio and host audio backend libraries.
+    # GUI player uses host PortAudio and host audio backend libraries
     a.binaries = _drop_entries(
         a.binaries,
         lambda entry: _entry_name_startswith(entry, _HOST_AUDIO_LIB_PREFIXES),
@@ -361,7 +366,7 @@ exe = EXE(
     exclude_binaries=sys.platform == 'darwin',
     # uac_admin is intentionally NOT set here.
     # We handle elevation at runtime in app.py so the user can choose
-    # read-only mode if they decline UAC, rather than being blocked entirely.
+    # read-only mode if they decline UAC, rather than being blocked entirely
     disable_windowed_traceback=False,
     argv_emulation=False,
     target_arch=_macos_target_arch,

--- a/FleasionLinuxProxyHelper.spec
+++ b/FleasionLinuxProxyHelper.spec
@@ -1,4 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
+import sys
+
+_use_upx = sys.platform == 'win32'
 
 a = Analysis(
     ['src/Fleasion/linux_proxy_helper_daemon.py'],
@@ -25,7 +28,7 @@ exe = EXE(
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=_use_upx,
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=False,

--- a/FleasionProxyHelper.spec
+++ b/FleasionProxyHelper.spec
@@ -2,7 +2,10 @@
 import os
 import sys
 
-_macos_target_arch = os.environ.get('MACOS_TARGET_ARCH') if sys.platform == 'darwin' else None
+_macos_target_arch = (
+    os.environ.get('MACOS_TARGET_ARCH') if sys.platform == 'darwin' else None
+)
+_use_upx = sys.platform == 'win32'
 
 a = Analysis(
     ['src/Fleasion/macos_proxy_helper_daemon.py'],
@@ -29,7 +32,7 @@ exe = EXE(
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=_use_upx,
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=False,

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -15,9 +15,6 @@ EXEC_PATH="${APP_PATH}/Contents/MacOS/${EXEC_NAME}"
 HELPER_EXEC_NAME="fleasion-proxy-helper"
 HELPER_ARM64_EXEC_NAME="${HELPER_EXEC_NAME}-arm64"
 HELPER_X86_EXEC_NAME="${HELPER_EXEC_NAME}-x86_64"
-HELPER_DIST_PATH="dist/${HELPER_EXEC_NAME}"
-HELPER_ARM64_DIST_PATH="dist/${HELPER_ARM64_EXEC_NAME}"
-HELPER_X86_DIST_PATH="dist/${HELPER_X86_EXEC_NAME}"
 
 MACOS_TARGET_ARCH="${MACOS_TARGET_ARCH:-universal2}"
 MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-10.15}"
@@ -346,42 +343,11 @@ verify_macos_compatibility() {
     rm -f "$unavailable_frameworks" "$incompatible_minos"
 }
 
-save_arch_helper() {
-    target_arch="$1"
-    case "$target_arch" in
-        arm64)
-            arch_helper_path="$HELPER_ARM64_DIST_PATH"
-            arch_helper_name="$HELPER_ARM64_EXEC_NAME"
-            ;;
-        x86_64)
-            arch_helper_path="$HELPER_X86_DIST_PATH"
-            arch_helper_name="$HELPER_X86_EXEC_NAME"
-            ;;
-        *)
-            echo "Unsupported helper architecture: $target_arch" >&2
-            exit 1
-            ;;
-    esac
-
-    cp "$HELPER_DIST_PATH" "$arch_helper_path"
-    chmod "$(stat -f %Lp "$HELPER_DIST_PATH")" "$arch_helper_path"
-    require_only_archs "$arch_helper_path" "$target_arch"
-    echo "Saved ${arch_helper_name} (${target_arch})"
-}
-
 build_current_arch() {
     target_arch="$1"
     macos_python_path="$(find_macos_python)"
     rm -rf "$UV_MACOS_PROJECT_ENVIRONMENT"
     macos_uv sync --locked --python "$macos_python_path" --group dev
-
-    MACOS_TARGET_ARCH="$target_arch" macos_uv run --python "$macos_python_path" pyinstaller --clean --noconfirm FleasionProxyHelper.spec
-    if [ ! -x "$HELPER_DIST_PATH" ]; then
-        echo "Helper build completed, but expected executable was not found: $HELPER_DIST_PATH" >&2
-        exit 1
-    fi
-    require_archs "$HELPER_DIST_PATH" "$target_arch"
-    save_arch_helper "$target_arch"
 
     MACOS_TARGET_ARCH="$target_arch" macos_uv run --python "$macos_python_path" pyinstaller --clean --noconfirm Fleasion.spec
 
@@ -416,16 +382,6 @@ build_x86_64() {
     x86_python_path="$(find_x86_python)"
     rm -rf "$UV_X86_PROJECT_ENVIRONMENT"
     x86_uv sync --locked --python "$x86_python_path" --group dev
-
-    MACOS_TARGET_ARCH=x86_64 \
-    x86_uv run --python "$x86_python_path" pyinstaller --clean --noconfirm FleasionProxyHelper.spec
-
-    if [ ! -x "$HELPER_DIST_PATH" ]; then
-        echo "Intel helper build completed, but expected executable was not found: $HELPER_DIST_PATH" >&2
-        exit 1
-    fi
-    require_archs "$HELPER_DIST_PATH" x86_64
-    save_arch_helper x86_64
 
     MACOS_TARGET_ARCH=x86_64 \
     x86_uv run --python "$x86_python_path" pyinstaller --clean --noconfirm Fleasion.spec

--- a/tests/test_build_macos_script.py
+++ b/tests/test_build_macos_script.py
@@ -27,7 +27,9 @@ def _build_script_functions() -> str:
     return '\n'.join(functions)
 
 
-def _run_verify_app_bundle(tmp_path: Path, app_path: Path) -> subprocess.CompletedProcess[str]:
+def _run_verify_app_bundle(
+    tmp_path: Path, app_path: Path
+) -> subprocess.CompletedProcess[str]:
     runner = tmp_path / 'verify_app_bundle.sh'
     runner.write_text(
         '\n'.join(
@@ -62,7 +64,7 @@ def _write_info_plist(
     icon_file: str = 'fleasionlogoHR.icns',
 ) -> None:
     (app_path / 'Contents' / 'Info.plist').write_text(
-        f'''<?xml version="1.0" encoding="UTF-8"?>
+        f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -74,7 +76,7 @@ def _write_info_plist(
 \t<string>{package_type}</string>
 </dict>
 </plist>
-''',
+""",
         encoding='utf-8',
     )
 
@@ -119,7 +121,9 @@ def test_macos_build_script_creates_permission_preserving_zip():
     assert 'ZIP_PATH="dist/${EXEC_NAME}-MacOS-Universal.zip"' in script
     assert 'ditto -c -k --sequesterRsrc --keepParent "$app_path" "$ZIP_PATH"' in script
     assert 'verify_zip_package "$ZIP_PATH"' in script
-    assert 'verify_app_bundle "${zip_check_dir}/${EXEC_NAME}.app" "Packaged zip"' in script
+    assert (
+        'verify_app_bundle "${zip_check_dir}/${EXEC_NAME}.app" "Packaged zip"' in script
+    )
     assert 'verify_app_archs "${zip_check_dir}/${EXEC_NAME}.app"' in script
     assert 'MacOS-Universal.dmg' not in script
     assert 'hdiutil create' not in script
@@ -138,13 +142,22 @@ def test_macos_build_targets_catalina_compatible_qt_runtime():
     assert 'case " $archs " in *" x86_64 "*) ;; *) continue ;; esac' in script
     assert 'otool -arch x86_64 -L "$file_path"' in script
     assert 'otool -arch x86_64 -l "$file_path"' in script
-    assert 'App contains binaries requiring newer than macOS ${MACOSX_DEPLOYMENT_TARGET}' in script
+    assert (
+        'App contains binaries requiring newer than macOS ${MACOSX_DEPLOYMENT_TARGET}'
+        in script
+    )
     assert 'verify_macos_compatibility "$app_path"' in script
     assert '\'pyqt6==6.2.3; platform_system == "Darwin"\'' in project
     assert '\'pyqt6-qt6==6.2.4; platform_system == "Darwin"\'' in project
     assert '\'pyqt6>=6.8.0; platform_system != "Darwin"\'' in project
-    assert '\'numpy==1.26.4; platform_system == "Darwin" and python_version < "3.13"\'' in project
-    assert '\'numpy>=2.0.0; platform_system != "Darwin" or python_version >= "3.13"\'' in project
+    assert (
+        '\'numpy==1.26.4; platform_system == "Darwin" and python_version < "3.13"\''
+        in project
+    )
+    assert (
+        '\'numpy>=2.0.0; platform_system != "Darwin" or python_version >= "3.13"\''
+        in project
+    )
 
 
 def test_macos_build_bundles_arch_specific_proxy_helpers():
@@ -153,8 +166,19 @@ def test_macos_build_bundles_arch_specific_proxy_helpers():
 
     assert 'HELPER_ARM64_EXEC_NAME="${HELPER_EXEC_NAME}-arm64"' in script
     assert 'HELPER_X86_EXEC_NAME="${HELPER_EXEC_NAME}-x86_64"' in script
-    assert 'save_arch_helper "$target_arch"' in script
-    assert 'save_arch_helper x86_64' in script
+    assert (
+        'MACOS_TARGET_ARCH="$target_arch" macos_uv run --python "$macos_python_path" pyinstaller --clean --noconfirm Fleasion.spec'
+        in script
+    )
+    assert (
+        'x86_uv run --python "$x86_python_path" pyinstaller --clean --noconfirm Fleasion.spec'
+        in script
+    )
+    assert 'FleasionProxyHelper.spec' in spec
+    assert (
+        'shutil.copy2(_bundled_legacy_macos_helper, _bundled_macos_helpers[target_arch])'
+        in spec
+    )
     assert 'require_only_archs "$arm_helper_path" arm64' in script
     assert 'require_only_archs "$x86_helper_path" x86_64' in script
     assert 'contains unexpected $found_arch slice; expected only' in script
@@ -162,8 +186,8 @@ def test_macos_build_bundles_arch_specific_proxy_helpers():
     assert 'Cryptodome/Hash/_ghash_clmul.abi3.so:x86_64' in script
     assert 'Cryptodome/Cipher/_raw_aesni.abi3.so:x86_64' in script
     assert 'cp -p "$x86_file" "$universal_file"' in script
-    assert "pathlib.Path('dist/fleasion-proxy-helper-arm64')" in spec
-    assert "pathlib.Path('dist/fleasion-proxy-helper-x86_64')" in spec
+    assert "Path('dist/fleasion-proxy-helper-arm64')" in spec
+    assert "Path('dist/fleasion-proxy-helper-x86_64')" in spec
 
 
 def test_macos_build_bundles_audio_runtime_libraries():
@@ -171,7 +195,8 @@ def test_macos_build_bundles_audio_runtime_libraries():
     spec = Path('Fleasion.spec').read_text(encoding='utf-8')
 
     assert "('_sounddevice_data', '_soundfile_data')" in spec
-    assert "collect_all(audio_runtime_package)" in spec
+    assert 'def _collect_optional_package(package: str)' in spec
+    assert 'collect_all(package)' in spec
     assert "'libportaudio.so'" in spec
     assert "'libpulse.so'" in spec
     assert "'libjack.so'" in spec
@@ -218,18 +243,39 @@ def test_draft_release_workflow_builds_main_and_uploads_versioned_assets():
     assert 'Checkout main for release' in workflow
     assert 'ref: ${{ needs.prepare.outputs.main_sha }}' in workflow
     assert 'release_tag: v${{ steps.version.outputs.app_version }}' in workflow
-    assert 'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}.exe' in workflow
-    assert 'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip' in workflow
-    assert 'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip' in workflow
+    assert (
+        'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}.exe'
+        in workflow
+    )
+    assert (
+        'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip'
+        in workflow
+    )
+    assert (
+        'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip'
+        in workflow
+    )
     assert 'artifact_path: dist/Fleasion-v*.exe' in workflow
     assert 'artifact_path: dist/Fleasion-v*-Linux.zip' in workflow
     assert 'artifact_path: dist/Fleasion-v*-MacOS-Universal.zip' in workflow
-    assert 'zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip"' in workflow
+    assert (
+        'zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip"'
+        in workflow
+    )
+    assert (
+        'zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip" '
+        '"Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux"' in workflow
+    )
     assert 'archive: false' in workflow
     assert 'uses: actions/download-artifact@v8' in workflow
     assert 'name: Fleasion-v${{ needs.prepare.outputs.app_version }}.exe' in workflow
-    assert 'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip' in workflow
-    assert 'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip' in workflow
+    assert (
+        'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip' in workflow
+    )
+    assert (
+        'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip'
+        in workflow
+    )
     assert 'skip-decompress: true' in workflow
     assert 'gh release create "$RELEASE_TAG" release-files/*' in workflow
     assert '--draft' in workflow
@@ -238,7 +284,11 @@ def test_draft_release_workflow_builds_main_and_uploads_versioned_assets():
 
 def test_github_workflow_verifies_linux_gui_audio_runtime():
     workflow = Path('.github/workflows/build.yml').read_text(encoding='utf-8')
+    spec = Path('Fleasion.spec').read_text(encoding='utf-8')
 
+    assert 'artifact_path: dist/Fleasion-v*-Linux' in workflow
+    assert 'dist/Fleasion-v*-Linux)' in workflow
+    assert "_exe_name = f'{_exe_name}-Linux'" in spec
     assert 'libpipewire-0.3-0' in workflow
     assert 'libspa-0.2-modules' in workflow
     assert 'libpulse0' in workflow
@@ -288,4 +338,6 @@ def test_verify_app_bundle_rejects_plist_executable_mismatch(tmp_path):
     result = _run_verify_app_bundle(tmp_path, app_path)
 
     assert result.returncode != 0
-    assert "CFBundleExecutable is 'Fleasion' instead of 'Fleasion-v2.2.1'" in result.stderr
+    assert (
+        "CFBundleExecutable is 'Fleasion' instead of 'Fleasion-v2.2.1'" in result.stderr
+    )

--- a/tests/test_build_macos_script.py
+++ b/tests/test_build_macos_script.py
@@ -218,8 +218,14 @@ def test_pyinstaller_spec_bundles_pyopengl_wayland_backend():
 def test_github_workflow_uploads_macos_zip_without_artifact_rezipping():
     workflow = Path('.github/workflows/build.yml').read_text(encoding='utf-8')
 
+    assert 'uses: actions/checkout@v7' in workflow
+    assert (
+        'uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0'
+        in workflow
+    )
     assert 'artifact_path: dist/Fleasion-v*-MacOS-Universal.zip' in workflow
     assert 'uses: actions/upload-artifact@v7' in workflow
+    assert 'uses: actions/upload-artifact@v6' not in workflow
     assert 'name: Fleasion-v${{ env.APP_VERSION }}-MacOS-Universal.zip' in workflow
     assert 'archive: false' in workflow
     assert 'artifact_path: dist/Fleasion-v*-MacOS-Universal.dmg' not in workflow
@@ -239,6 +245,11 @@ def test_draft_release_workflow_builds_main_and_uploads_versioned_assets():
 
     assert 'workflow_dispatch:' in workflow
     assert 'contents: write' in workflow
+    assert 'uses: actions/checkout@v7' in workflow
+    assert (
+        'uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0'
+        in workflow
+    )
     assert 'ref: main' in workflow
     assert 'Checkout main for release' in workflow
     assert 'ref: ${{ needs.prepare.outputs.main_sha }}' in workflow
@@ -248,7 +259,7 @@ def test_draft_release_workflow_builds_main_and_uploads_versioned_assets():
         in workflow
     )
     assert (
-        'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip'
+        'artifact_name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux'
         in workflow
     )
     assert (
@@ -256,22 +267,14 @@ def test_draft_release_workflow_builds_main_and_uploads_versioned_assets():
         in workflow
     )
     assert 'artifact_path: dist/Fleasion-v*.exe' in workflow
-    assert 'artifact_path: dist/Fleasion-v*-Linux.zip' in workflow
+    assert 'artifact_path: dist/Fleasion-v*-Linux' in workflow
     assert 'artifact_path: dist/Fleasion-v*-MacOS-Universal.zip' in workflow
-    assert (
-        'zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip"'
-        in workflow
-    )
-    assert (
-        'zip -9 "Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip" '
-        '"Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux"' in workflow
-    )
+    assert 'Package Linux release zip' not in workflow
+    assert 'zip -9' not in workflow
     assert 'archive: false' in workflow
     assert 'uses: actions/download-artifact@v8' in workflow
     assert 'name: Fleasion-v${{ needs.prepare.outputs.app_version }}.exe' in workflow
-    assert (
-        'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux.zip' in workflow
-    )
+    assert 'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-Linux' in workflow
     assert (
         'name: Fleasion-v${{ needs.prepare.outputs.app_version }}-MacOS-Universal.zip'
         in workflow


### PR DESCRIPTION
## Summary

- Reduce PyInstaller bundle size by narrowing collected Qt/runtime dependencies
- Move proxy helper builds into `Fleasion.spec` so CI only needs to build the main spec
- Enable UPX for Windows CI builds
- Rename Linux release artifacts with a `-Linux` suffix and upload the raw binary directly
- Update workflow action versions for build and draft release jobs
