### PR TITLE
Fix incorrect version discovery in packaged builds

### DIFF
--- a/Fleasion.spec
+++ b/Fleasion.spec
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+from importlib.metadata import PackageNotFoundError, version as distribution_version
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -241,6 +242,15 @@ def _build_macos_helper(target_arch: str | None) -> None:
 
 _version = _read_app_version()
 _exe_name = f'Fleasion-v{_version}'
+try:
+    _distribution_version = distribution_version('Fleasion')
+except PackageNotFoundError:
+    raise SystemExit('Fleasion distribution metadata is missing. Run uv sync before building.')
+if _distribution_version != _version:
+    raise SystemExit(
+        f'Fleasion distribution metadata is {_distribution_version}, but pyproject.toml '
+        f'declares {_version}. Run uv sync before building.'
+    )
 if sys.platform == 'win32':
     _exe_name = f'{_exe_name}-Windows'
 elif sys.platform.startswith('linux'):

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ uv version --bump patch
 # or: uv version <new-version>
 ```
 
-Runtime code, PyInstaller naming, and GitHub release workflows read that value from `pyproject.toml`.
+Source runs, PyInstaller naming, and GitHub release workflows read that value from `pyproject.toml`.
+PyInstaller packages the matching distribution metadata for runtime version checks.
 
 ## System Tray
 

--- a/src/fleasion/version.py
+++ b/src/fleasion/version.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import tomllib
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -11,23 +12,27 @@ _UNKNOWN_VERSION = '0.0.0'
 
 
 def _read_pyproject_version() -> str | None:
-    for parent in Path(__file__).resolve().parents:
-        pyproject_path = parent / 'pyproject.toml'
-        if not pyproject_path.is_file():
-            continue
-
-        pyproject = tomllib.loads(pyproject_path.read_text(encoding='utf-8'))
-        project = pyproject.get('project')
-        if not isinstance(project, dict):
-            return None
-
-        project_version = project.get('version')
-        if isinstance(project_version, str) and project_version:
-            return project_version
-
+    module_path = Path(__file__).resolve()
+    try:
+        project_root = module_path.parents[2]
+    except IndexError:
         return None
 
-    return None
+    source_module_path = project_root / 'src' / 'fleasion' / module_path.name
+    if source_module_path.resolve() != module_path:
+        return None
+
+    pyproject_path = project_root / 'pyproject.toml'
+    if not pyproject_path.is_file():
+        return None
+
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding='utf-8'))
+    project = pyproject.get('project')
+    if not isinstance(project, dict) or project.get('name') != _DISTRIBUTION_NAME:
+        return None
+
+    project_version = project.get('version')
+    return project_version if isinstance(project_version, str) and project_version else None
 
 
 def _read_installed_version() -> str | None:
@@ -38,4 +43,7 @@ def _read_installed_version() -> str | None:
 
 
 def read_version() -> str:
+    if getattr(sys, 'frozen', False):
+        return _read_installed_version() or _UNKNOWN_VERSION
+
     return _read_pyproject_version() or _read_installed_version() or _UNKNOWN_VERSION

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+from fleasion import version
+
+
+def test_frozen_version_uses_distribution_metadata(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(version.sys, 'frozen', True, raising=False)
+    monkeypatch.setattr(version, '_read_pyproject_version', lambda: '0.1.0')
+    monkeypatch.setattr(version, '_read_installed_version', lambda: '2.3.0')
+
+    assert version.read_version() == '2.3.0'
+
+
+def test_source_version_falls_back_to_pyproject(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    package_path = tmp_path / 'src' / 'fleasion'
+    package_path.mkdir(parents=True)
+    fake_module_path = package_path / 'version.py'
+    fake_module_path.touch()
+    (tmp_path / 'pyproject.toml').write_text(
+        "[project]\nname = 'Fleasion'\nversion = '2.3.0'\n",
+        encoding='utf-8',
+    )
+
+    monkeypatch.setattr(version, '__file__', str(fake_module_path))
+    monkeypatch.setattr(version, '_read_installed_version', lambda: '0.1.0')
+
+    assert version.read_version() == '2.3.0'
+
+
+def test_unrelated_parent_pyproject_is_ignored(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    package_path = tmp_path / 'temporary-extraction' / 'fleasion'
+    package_path.mkdir(parents=True)
+    fake_module_path = package_path / 'version.py'
+    fake_module_path.touch()
+    (tmp_path / 'pyproject.toml').write_text(
+        "[project]\nname = 'unrelated-project'\nversion = '0.1.0'\n",
+        encoding='utf-8',
+    )
+
+    monkeypatch.setattr(version, '__file__', str(fake_module_path))
+    monkeypatch.setattr(version, '_read_installed_version', lambda: '2.3.0')
+
+    assert version.read_version() == '2.3.0'


### PR DESCRIPTION
## Summary

Fixes PyInstaller builds sometimes reporting a version from an unrelated `pyproject.toml`, such as `0.1.0`, instead of Fleasion's actual version.

## Root cause

Version discovery previously searched every parent directory of `fleasion/version.py` for a `pyproject.toml`.

PyInstaller one-file applications extract into a temporary `_MEI...` directory. If that directory or one of its parents contained an unrelated `pyproject.toml`, Fleasion used that project's version before checking its bundled distribution metadata.

This made the same executable report different versions depending on the user's temporary-directory layout.

## Changes

- Detect frozen/PyInstaller execution using `getattr(sys, 'frozen', False)`.
- Always use bundled distribution metadata in frozen builds.
- Only read `pyproject.toml` from Fleasion's expected source layout.
- Verify that the source project is named `Fleasion`.
- Reject builds when installed distribution metadata differs from `pyproject.toml`.